### PR TITLE
Update registration links based on ref

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,1 +1,9 @@
+'use client'
 
+window.addEventListener('load',  () => {
+  const ref = new URL(location.href).searchParams.get('ref')
+  if (!ref) return
+
+  document.querySelectorAll<HTMLAnchorElement>('a[href$="/register/"]')
+    .forEach(a => { a.href += '?ref=' + encodeURIComponent(ref) })
+})

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { WorkshopsSection } from './workshops-section'
 import { JudgesSection } from './judges-section'
 import { FAQSection } from './faq-section'
 import { PageFooter } from './footer'
+import './index'
 
 export default function Home() {
   return (


### PR DESCRIPTION
If taken to `https://seminar.treasurehacks.org/?ref=test`, then **both** registration links should take you to `/register/?ref=test`